### PR TITLE
Remove site-install from init command

### DIFF
--- a/commands/host/dkan-init
+++ b/commands/host/dkan-init
@@ -58,5 +58,4 @@ ddev composer install
 cat .ddev/misc/settings.dkan-snippet.php.txt >> docroot/sites/default/settings.php
 cp .ddev/misc/settings.dkan.php docroot/sites/default/settings.dkan.php
 
-ddev dkan-site-install
 echo "Site build complete. Type 'ddev launch' to visit the site."

--- a/commands/host/dkan-init
+++ b/commands/host/dkan-init
@@ -58,4 +58,4 @@ ddev composer install
 cat .ddev/misc/settings.dkan-snippet.php.txt >> docroot/sites/default/settings.php
 cp .ddev/misc/settings.dkan.php docroot/sites/default/settings.dkan.php
 
-echo "Site build complete. Type 'ddev launch' to visit the site."
+echo "Site codebase initialized."

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ TODO: Make a release and add the addon tag to our repo so DDev can find it.
 
 ## Start a new DKAN site
 
-First set up for using DKAN:
+First, set up your DKAN site:
 
     # Make a directory for your project.
     mkdir my-project && cd my_project
@@ -24,6 +24,8 @@ First set up for using DKAN:
     ddev restart
     # Initialize the site.
     ddev dkan-init
+    # Install Drupal.
+    ddev dkan-site-install
 
 Now we have a useful DKAN-based Drupal site, so let's take a look, and use the
 standard tools to log in:
@@ -31,6 +33,12 @@ standard tools to log in:
     ddev launch
     ddev drush status-report
     ddev drush uli
+
+If you are doing development work on the DKAN module itself, you can substitute
+the `ddev dkan-init --moduledev` command for `ddev dkan-init`.
+
+This will clone the dkan project into its own directory and tell Composer to
+use that repo as the getdkan/dkan package.
 
 ### TODO
 

--- a/tests/init.bats
+++ b/tests/init.bats
@@ -13,6 +13,7 @@ setup() {
   cd "${TESTDIR}"
   ddev config --project-name=${PROJNAME}
   ddev get ${DIR}
+  ddev restart
 }
 
 teardown() {
@@ -26,7 +27,6 @@ teardown() {
 @test "dkan-init" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
 
   run ddev dkan-init --help
   assert_output --partial "--moduledev"
@@ -36,15 +36,14 @@ teardown() {
 
   run ddev dkan-init
   refute_output --partial "Setting up for local DKAN module development"
-  assert_output --partial "Site build complete. Type 'ddev launch' to visit the site."
+  assert_output --partial "Site codebase initialized."
 }
 
 @test "dkan-init-moduledev" {
   set -eu -o pipefail
   cd ${TESTDIR}
-  echo "# ddev get ${DIR} with project ${PROJNAME} in ${TESTDIR} ($(pwd))" >&3
 
   run ddev dkan-init --moduledev
   assert_output --partial "Setting up for local DKAN module development"
-  assert_output --partial "Site build complete. Type 'ddev launch' to visit the site."
+  assert_output --partial "Site codebase initialized."
 }


### PR DESCRIPTION
Let's make people run dkan-site-install manually for now, init should just get our codebase ready.