### PR TITLE
Use ssh for git

### DIFF
--- a/commands/host/dkan-init
+++ b/commands/host/dkan-init
@@ -8,7 +8,7 @@
 # Fail early, fail often.
 set -euo pipefail
 
-export DKAN_REPO=https://github.com/GetDKAN/dkan.git
+export DKAN_REPO=git@github.com:GetDKAN/dkan.git
 export DKAN_REPO_BRANCH=2.x
 export DKAN_DIRECTORY=dkan
 


### PR DESCRIPTION
When we use `--moduledev` it's for pushing changes back to DKAN; makes more sense IMO to use SSH rather than HTTPS for the repo URL.