### PR TITLE
Better/simpler phpunit commmand

### DIFF
--- a/commands/web/dkan-phpunit
+++ b/commands/web/dkan-phpunit
@@ -1,10 +1,9 @@
 #!/bin/bash
 
-## Description: (DEPRECATED - use dkan-phpunit) Run PHPUnit tests for the DKAN module.
-## Usage: dkan-test-phpunit <arguments>
+## Description: Run PHPUnit tests for the DKAN module.
+## Usage: dkan-phpunit <arguments>
 
-# Avoid some XDebug error messages.
-export XDEBUG_MODE=coverage
+export XDEBUG_MODE=coverage,debug
 
 TEST_PATH="docroot/modules/contrib/dkan"
 TEST_SUITE="DKAN Test Suite"
@@ -15,12 +14,6 @@ if [[ ! -f $PHPUNIT_BINARY ]] ; then
   echo "Unable to find PHPUnit executable at $PHPUNIT_BINARY. Performing composer install."
   composer install --no-progress
 fi
-
-# Ensure prophecy.
-composer require --dev phpspec/prophecy-phpunit:^2
-
-# Add fixture users.
-./.ddev/commands/web/dkan-test-users
 
 echo "Starting PHPUnit test run."
 DDEV_PATH="$PWD"
@@ -40,9 +33,5 @@ DRUPAL_ROOT="/var/www/html/docroot" \
   --fail-on-risky \
   "$@"
 TEST_RESULTS=$?
-
-# Clean up fixture users.
-cd $DDEV_PATH || exit 1
-./.ddev/commands/web/dkan-test-users --remove
 
 exit $TEST_RESULTS

--- a/commands/web/dkan-phpunit
+++ b/commands/web/dkan-phpunit
@@ -1,10 +1,28 @@
 #!/bin/bash
 
 #ddev-generated
-## Description: Run PHPUnit tests for the DKAN module.
-## Usage: dkan-phpunit <arguments>
+## Description: Run PHPUnit tests for the DKAN module. Any flags/args will be passed to phpunit (except --debug).
+## Usage: dkan-phpunit [flags] [args]
+## Flags: [{"Name":"debug", "Usage":"Put xdebug in debug mode. Always put first if using."}]
 
-export XDEBUG_MODE=coverage,debug
+XDEBUG_MODE=coverage
+
+while :; do
+  case ${1:-} in
+  --debug)
+    XDEBUG_MODE=debug
+    ;;
+  --) # End of all options.
+    break
+    ;;
+  *) # Default case: No more options, so break out of the loop.
+    break ;;
+  esac
+  shift
+done
+
+
+export XDEBUG_MODE
 
 TEST_PATH="docroot/modules/contrib/dkan"
 TEST_SUITE="DKAN Test Suite"

--- a/commands/web/dkan-phpunit
+++ b/commands/web/dkan-phpunit
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+#ddev-generated
 ## Description: Run PHPUnit tests for the DKAN module.
 ## Usage: dkan-phpunit <arguments>
 

--- a/commands/web/dkan-test-phpunit
+++ b/commands/web/dkan-test-phpunit
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+#ddev-generated
 ## Description: (DEPRECATED - use dkan-phpunit) Run PHPUnit tests for the DKAN module.
 ## Usage: dkan-test-phpunit <arguments>
 

--- a/docs/testing-dkan.md
+++ b/docs/testing-dkan.md
@@ -12,6 +12,10 @@ Then run the tests:
 
     ddev dkan dkan-phpunit
 
+The tests will run by default with xdebug in "coverage" mode, to facilitate building
+coverage reports in XML or HTML. If you want to use a step debugger locally, add the
+`--debug` flag before any other flags or arguments.
+
 ## Testing with Cypress locally
 
 You will need a locally-installed Cypress binary, version 8. (DKAN frontend

--- a/docs/testing-dkan.md
+++ b/docs/testing-dkan.md
@@ -4,13 +4,13 @@
 
 Your process should set up the site:
 
-    ddev dkan dkan-init
+    ddev dkan-init
     # optionally: ddev dkan-init --moduledev
     ddev dkan-site-install
 
 Then run the tests:
 
-    ddev dkan dkan-phpunit
+    ddev dkan-phpunit
 
 The tests will run by default with xdebug in "coverage" mode, to facilitate building
 coverage reports in XML or HTML. If you want to use a step debugger locally, add the

--- a/docs/testing-dkan.md
+++ b/docs/testing-dkan.md
@@ -10,9 +10,7 @@ Your process should set up the site:
 
 Then run the tests:
 
-    ddev dkan dkan-test-phpunit
-
-This command will call the `dkan-test-users` command to create test users.
+    ddev dkan dkan-phpunit
 
 ## Testing with Cypress locally
 

--- a/install.yaml
+++ b/install.yaml
@@ -63,6 +63,7 @@ project_files:
   - commands/web/dkan-frontend-build
   - commands/web/dkan-frontend-install
   - commands/web/dkan-get-env-for-phpunit
+  - commands/web/dkan-phpunit
   - commands/web/dkan-site-install
   - commands/web/dkan-test-phpunit
   - commands/web/dkan-test-users

--- a/tests/phpunit.bats
+++ b/tests/phpunit.bats
@@ -35,7 +35,7 @@ teardown() {
 
   # Run a test group that does not exist, since we're not actually testing
   # PHP code here.
-  run ddev dkan-test-phpunit --group this-group-should-not-exist
+  run ddev dkan-phpunit --group this-group-should-not-exist
   assert_output --partial 'Starting PHPUnit test run'
   assert_output --partial 'No tests executed!'
 }


### PR DESCRIPTION
By adding create user steps to DKAN core functional tests (see GetDKAN/dkan#3936), we remove the need to call the dkan-test-users command from dkan-test-phpunit. This PR replaces that whole command with a new one, dkan-phpunit, that removes this and a couple other unnecessary slow-down steps. Once we're satisfied with it we can remove dkan-test-phpunit from this repo.

I'd like to shorten and simplify other commands here as well in the future following this pattern - for instance I think dkan-module-test-cypress can just be dkan-cypress.