### PR TITLE
Don’t need to enable core modules with dependencies updated in #3922

### DIFF
--- a/commands/web/dkan-site-install
+++ b/commands/web/dkan-site-install
@@ -9,7 +9,7 @@
 set -eu -o pipefail
 
 drush site:install minimal --site-name="DKAN" --account-name="admin" -y
-drush pm-enable dkan file link options automated_cron menu_ui admin_toolbar admin_toolbar_tools -y
+drush pm-enable dkan automated_cron admin_toolbar admin_toolbar_tools -y
 
 # Create administrator role and assign to user 1
 drush role:create "administrator" "Administrator" -y


### PR DESCRIPTION
Now that https://github.com/GetDKAN/dkan/pull/3922 explicitly includes non-minimal install core module dependencies as part of DKAN, these can be removed from the site install ddev command.