### PR TITLE
Add dump command and test

### DIFF
--- a/commands/web/dkan-update-test-dump
+++ b/commands/web/dkan-update-test-dump
@@ -21,24 +21,27 @@ else
   FILENAME="update.php.gz"
 fi
 
+FIXTURES_DIR="$DDEV_DOCROOT/modules/contrib/dkan/tests/fixtures/update"
+
 # If the file already exists, prompt the user to overwrite it.
-if [ -f "docroot/modules/contrib/dkan/tests/fixtures/update/$FILENAME" ]; then
+if [ -f "$FIXTURES_DIR/$FILENAME" ]; then
+  echo ""
   read -p "The file $FILENAME already exists. Overwrite? (y/n) " -n 1 -r
-  echo
   if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-    # Prompt user to enter a new filename.
-    read -p "Enter a new filename w/o extension (e.g. update-my-new-feaure): " FILENAME
-    FILENAME="$FILENAME.php.gz"
+    echo ""
+    echo "Exiting, delete or rename $FILENAME and run again."
+    exit 0
   fi
 fi
 
 # Create folder dkan/tests/fixtures/update if it does not exist.
-mkdir -p $DDEV_DOCROOT/modules/contrib/dkan/tests/fixtures/update
+mkdir -p $FIXTURES_DIR
 
 php $DDEV_DOCROOT/core/scripts/db-tools.php dump-database-d8-mysql \
-  | gzip > $DDEV_DOCROOT/modules/contrib/dkan/tests/fixtures/update/$FILENAME
+  | gzip > $FIXTURES_DIR/$FILENAME
 
-echo "Database dump for update tests created at $DDEV_DOCROOT/modules/contrib/dkan/tests/fixtures/update/$FILENAME"
+echo ""
+echo "Database dump for update tests created at $FIXTURES_DIR/$FILENAME"
 echo ""
 echo "For a test in DKAN's tests/src/Functional direcory, add this to \$databaseDumpFiles[]:"
 echo "  __DIR__ . '/fixtures/update/$FILENAME'"

--- a/commands/web/dkan-update-test-dump
+++ b/commands/web/dkan-update-test-dump
@@ -11,12 +11,6 @@
 # Fail early, fail often.
 set -eu -o pipefail
 
-# Exit if fixtures directory does not exist.
-if [ ! -d "docroot/modules/contrib/dkan/tests/fixtures/update" ]; then
-  echo "The directory tests/fixtures/update does not exist in the DKAN module."
-  exit 1
-fi
-
 if [ -d "dkan" ]; then
   cd dkan
   # Get latest release tag
@@ -38,6 +32,9 @@ if [ -f "docroot/modules/contrib/dkan/tests/fixtures/update/$FILENAME" ]; then
   fi
 fi
 
+# Create folder dkan/tests/fixtures/update if it does not exist.
+mkdir -p $DDEV_DOCROOT/modules/contrib/dkan/tests/fixtures/update
+
 php $DDEV_DOCROOT/core/scripts/db-tools.php dump-database-d8-mysql \
   | gzip > $DDEV_DOCROOT/modules/contrib/dkan/tests/fixtures/update/$FILENAME
 
@@ -45,4 +42,7 @@ echo "Database dump for update tests created at $DDEV_DOCROOT/modules/contrib/dk
 echo ""
 echo "For a test in DKAN's tests/src/Functional direcory, add this to \$databaseDumpFiles[]:"
 echo "  __DIR__ . '/fixtures/update/$FILENAME'"
+echo ""
+echo "If you have checked out another tag or branch to create the dump, make
+sure to checkout your feature branch again before committing the dump file."
 

--- a/commands/web/dkan-update-test-dump
+++ b/commands/web/dkan-update-test-dump
@@ -1,0 +1,48 @@
+#!/bin/bash
+#ddev-generated
+
+## Description: Create a db dump file for update tests.
+## Usage: dkan-update-test-dump
+## Aliases: dkan-utd
+## Example: ddev dkan-utd
+
+## See https://www.drupal.org/node/2536494.
+
+# Fail early, fail often.
+set -eu -o pipefail
+
+# Exit if fixtures directory does not exist.
+if [ ! -d "docroot/modules/contrib/dkan/tests/fixtures/update" ]; then
+  echo "The directory tests/fixtures/update does not exist in the DKAN module."
+  exit 1
+fi
+
+if [ -d "dkan" ]; then
+  cd dkan
+  # Get latest release tag
+  BRANCH=$(git describe --tags --abbrev=0)
+  FILENAME="update-$BRANCH.php.gz"
+  cd ..
+else
+  FILENAME="update.php.gz"
+fi
+
+# If the file already exists, prompt the user to overwrite it.
+if [ -f "docroot/modules/contrib/dkan/tests/fixtures/update/$FILENAME" ]; then
+  read -p "The file $FILENAME already exists. Overwrite? (y/n) " -n 1 -r
+  echo
+  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+    # Prompt user to enter a new filename.
+    read -p "Enter a new filename w/o extension (e.g. update-my-new-feaure): " FILENAME
+    FILENAME="$FILENAME.php.gz"
+  fi
+fi
+
+php $DDEV_DOCROOT/core/scripts/db-tools.php dump-database-d8-mysql \
+  | gzip > $DDEV_DOCROOT/modules/contrib/dkan/tests/fixtures/update/$FILENAME
+
+echo "Database dump for update tests created at $DDEV_DOCROOT/modules/contrib/dkan/tests/fixtures/update/$FILENAME"
+echo ""
+echo "For a test in DKAN's tests/src/Functional direcory, add this to \$databaseDumpFiles[]:"
+echo "  __DIR__ . '/fixtures/update/$FILENAME'"
+

--- a/install.yaml
+++ b/install.yaml
@@ -66,6 +66,7 @@ project_files:
   - commands/web/dkan-site-install
   - commands/web/dkan-test-phpunit
   - commands/web/dkan-test-users
+  - commands/web/dkan-update-test-dump
   - commands/web/project-test-phpunit
   - misc/docker-compose.cypress.yaml
   - misc/phpunit.xml

--- a/tests/update-test-dump.bats
+++ b/tests/update-test-dump.bats
@@ -35,13 +35,7 @@ teardown() {
   ddev dkan-site-install
   run ddev dkan-update-test-dump
   assert_output --partial "Database dump for update tests created"
-  assert [ -f ${TESTDIR}/dkan/tests/fixtures/update/update-2.20.0.sql.gz ]
-  run ddev dkan-update-test-dump
-  assert_output --partial "The file $(FILENAME) already exists. Overwrite? (y/n)"
-  # Select 'n' to not overwrite the file
-  run echo "n"
-  assert_outpuut --partial "Enter a new filename"
-  run echo "something"
-  assert_output --partial "Database dump for update tests created"
-  assert [ -f ${TESTDIR}/dkan/tests/fixtures/update/something.sql.gz ]
+  ls -la ${TESTDIR}/dkan/tests/fixtures/update
+  assert [ -f ${TESTDIR}/dkan/tests/fixtures/update/update-2.20.0.php.gz ]
+  # @todo test file exists
 } 

--- a/tests/update-test-dump.bats
+++ b/tests/update-test-dump.bats
@@ -1,0 +1,39 @@
+setup() {
+  set -eu -o pipefail
+
+  load 'test_helper/bats-support/load'
+  load 'test_helper/bats-assert/load'
+
+  export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
+  export PROJNAME=test-dkan-ddev-addon
+  export TESTDIR=~/tmp/$PROJNAME
+  mkdir -p $TESTDIR
+  export DDEV_NON_INTERACTIVE=true
+  ddev delete -Oy ${PROJNAME} || true
+  cd "${TESTDIR}"
+  ddev config --project-name=${PROJNAME}
+  ddev addon get ${DIR}
+  ddev restart
+}
+
+teardown() {
+  set -eu -o pipefail
+  echo "teardown..."
+  cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
+  ddev delete -Oy ${PROJNAME}
+  [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
+}
+
+@test "set up for moduledev and create a db backup" {
+  set -eu -o pipefail
+  cd ${TESTDIR}
+
+  run ddev dkan-init --force --moduledev
+  cd dkan
+  git checkout tags/2.20.0
+  cd ..
+  ddev dkan-site-install
+  run ddev dkan-update-test-dump
+  assert_output --partial "Database dump for update tests created"
+  assert [ -f ${TESTDIR}/dkan/tests/fixtures/update/update-2.20.0.sql.gz]
+}

--- a/tests/update-test-dump.bats
+++ b/tests/update-test-dump.bats
@@ -35,5 +35,13 @@ teardown() {
   ddev dkan-site-install
   run ddev dkan-update-test-dump
   assert_output --partial "Database dump for update tests created"
-  assert [ -f ${TESTDIR}/dkan/tests/fixtures/update/update-2.20.0.sql.gz]
-}
+  assert [ -f ${TESTDIR}/dkan/tests/fixtures/update/update-2.20.0.sql.gz ]
+  run ddev dkan-update-test-dump
+  assert_output --partial "The file $(FILENAME) already exists. Overwrite? (y/n)"
+  # Select 'n' to not overwrite the file
+  run echo "n"
+  assert_outpuut --partial "Enter a new filename"
+  run echo "something"
+  assert_output --partial "Database dump for update tests created"
+  assert [ -f ${TESTDIR}/dkan/tests/fixtures/update/something.sql.gz ]
+} 


### PR DESCRIPTION
This command creates a special kind of db dump that is used for Drupal update tests. See https://www.drupal.org/node/2536494 for more information.

## QA Steps

1. Check out
2. Create a new site folder
3. `ddev config --auto`
4. `ddev addon get /path/to/ddev/addon`
5. `ddev restart`
6. `ddev dkan-init --moduledev`
7. `ddev dkan-site-install`
8. `git checkout -b new-update-test`
9. `ddev dkan-update-test-dump`
10. Confirm a new dump file was added to dkan/tests/fixtures/update
11. Try the command again twice, with each overwrite option.

You can also check out a previous tag of DKAN to create a dump from that. The filename should reflect the last DKAN tag release.

One thing I'm not sure of is if it makes sense to drop this right in the fixtures directory rather than in docroot or project root to be moved as needed. Feedback welcomed.