### PR TITLE
Remove flags annotation from dkan-phpunit

### DIFF
--- a/commands/web/dkan-phpunit
+++ b/commands/web/dkan-phpunit
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 #ddev-generated
-## Description: Run PHPUnit tests for the DKAN module. Any flags/args will be passed to phpunit (except --debug).
-## Usage: dkan-phpunit [flags] [args]
-## Flags: [{"Name":"debug", "Usage":"Put xdebug in debug mode. Always put first if using."}]
+## Description: Run PHPUnit tests for the DKAN module. Any flags/args will be passed to phpunit (except --debug, which puts xdebug in debug mode).
+## Usage: dkan-phpunit [--debug] [flags] [args]
 
 XDEBUG_MODE=coverage
 


### PR DESCRIPTION
The [1.24.7](https://github.com/ddev/ddev/releases/tag/v1.24.7) release of ddev changes how flags are handled. We now need to document all possible flags or none of them. Since the former is not practical, doing the latter here.